### PR TITLE
Configure winston only once

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -2,7 +2,22 @@ import * as Koa from 'koa';
 import { config } from './config';
 import * as winston from 'winston';
 
-export function logger(winstonInstance) {
+export function logger(winstonInstance) {    
+    winstonInstance.configure({
+        level: config.debugLogging ? 'debug' : 'info',
+        transports: [
+            //
+            // - Write all logs error (and below) to `error.log`.
+            new winston.transports.File({ filename: 'error.log', level: 'error' }),
+            //
+            // - Write to all logs with specified level to console.
+            new winston.transports.Console({ format: winston.format.combine(
+                winston.format.colorize(),
+                winston.format.simple()
+              ) })
+        ]
+    });
+
     return async(ctx: Koa.Context, next: () => Promise<any>) => {
 
         const start = new Date().getMilliseconds();
@@ -23,21 +38,6 @@ export function logger(winstonInstance) {
         }
 
         const msg: string = `${ctx.method} ${ctx.originalUrl} ${ctx.status} ${ms}ms`;
-
-        winstonInstance.configure({
-            level: config.debugLogging ? 'debug' : 'info',
-            transports: [
-                //
-                // - Write all logs error (and below) to `error.log`.
-                new winston.transports.File({ filename: 'error.log', level: 'error' }),
-                //
-                // - Write to all logs with specified level to console.
-                new winston.transports.Console({ format: winston.format.combine(
-                    winston.format.colorize(),
-                    winston.format.simple()
-                  ) })
-            ]
-        });
 
         winstonInstance.log(logLevel, msg);
     };


### PR DESCRIPTION
Moves winston configuration into body of logger factory -- winston was being re-configured after every middleware pipeline invocation, resulting in memory leaks and duplicate log output.